### PR TITLE
Just typos

### DIFF
--- a/content/post/2023/01-nocpu-3d-game.md
+++ b/content/post/2023/01-nocpu-3d-game.md
@@ -69,7 +69,7 @@ The above pipeline uses operations on custom floating and fixed point types.
 |Float Fast Reciprocal Square Root| 3 stages  |
 |Float Fast Square Root           | 3 stages  |
 |Float Fast Division              | 4 stages  |
-|Float 3D Vector Dot Produc       | 5 stages  |
+|Float 3D Vector Dot Product      | 5 stages  |
 |Float 3D Vector Normalize        | 7 stages  |
 |Ray Plane Intersection           | 10 stages |
 |Ray Sphere Intersection          | 22 stages |

--- a/content/post/2023/01-nocpu-3d-game.md
+++ b/content/post/2023/01-nocpu-3d-game.md
@@ -77,8 +77,8 @@ The above pipeline uses operations on custom floating and fixed point types.
 
 Float types use a 14 bit mantissa instead of the typical 23 bits, and fixed point values are represented with a total of 22 bits: 12 for integer portion, 10 for the fractional bits. Those types are provided by CflexHDL types and can the effects of reduced precision can be readily appreciated with the provided graphical simulation tool, so the optimal size is easy to determine by performing the fast simulations.
 
-![image](https://user-images.githubusercontent.com/8551129/215368154-a9abd122-1308-4c15-b39b-7b19be07082d.png)
-<br>_Full precision vs. reduced precision in simulator window_
+![image](https://user-images.githubusercontent.com/8551129/215368154-a9abd122-1308-4c15-b39b-7b19be07082d.png)  
+_Full precision vs. reduced precision in simulator window_
 
 Typical times for development/test cycles are as follows:
 |                         | Build command   | Build time|  Speed @1080p |


### PR DESCRIPTION
Thanks again for allowing us to publish the article!
I'd like to correct simple typos and formatting, like this text not appearing directly below the image as intended
Otherwise it seems perfect

![image](https://user-images.githubusercontent.com/8551129/216676549-b4ddd1b1-e15b-4224-9c74-1aa91e4e8edf.png)
 