### PR TITLE
With a valid link to my blog, it's better

### DIFF
--- a/content/post/2023/14-solving-a-sudoku-with-symbiyosys-and-formal-verification.md
+++ b/content/post/2023/14-solving-a-sudoku-with-symbiyosys-and-formal-verification.md
@@ -11,7 +11,7 @@ _This guest post is by Theophile Loubiere._
 
 # Solving a Sudoku with SBY and Formal Verification
 
-Recently, I began using SBY to formally verify my designs. You can check out my first attempt on my blog [learn-fpga-easily](https://learn-fpga-easily.com/trying-formal-verification-with-SBY-and-chisel/). Formal Verification helps ensure that certain properties of your design always remain true, such as:
+Recently, I began using SBY to formally verify my designs. You can check out my first attempt on my blog [learn-fpga-easily](https://learn-fpga-easily.com/trying-formal-verification-with-symbiyosys-and-chisel/). Formal Verification helps ensure that certain properties of your design always remain true, such as:
 
 - **Bus arbitration**: "Only one master can receive the bus grant at any given time."
 - **Overflow and Underflow**: "The FIFO buffer will never overflow or underflow."


### PR DESCRIPTION
When replacing "symbiyosys" by "SBY" i did not notice that it change the link to the blog post on my website. Otherwise it leads to a 404 on my website (I want to die...). I did a redirect on my website, so people that click on the unvalid link still goes to the intended blog post. But it is better to have a valid link directly. 